### PR TITLE
Handle no mutations

### DIFF
--- a/genotype_variants/commands/small_variants.py
+++ b/genotype_variants/commands/small_variants.py
@@ -552,7 +552,13 @@ def create_empty_maf_if_missing(filename):
         'n_alt_count',
         'Caller',
         't_total_count',
-        't_variant_frequency']
+        't_variant_frequency',
+        't_total_count_forward',
+        't_ref_count_forward',
+        't_alt_count_forward',
+        't_total_count_fragment',
+        't_ref_count_fragment',
+        't_alt_count_fragment']
 
     if not os.path.exists(filename):
         empty_df = pd.DataFrame(columns=header)

--- a/genotype_variants/commands/small_variants.py
+++ b/genotype_variants/commands/small_variants.py
@@ -374,10 +374,10 @@ def generate_gbcms_cmd(
 def merge(
     patient_id, input_maf, input_standard_maf, input_duplex_maf, input_simplex_maf
 ):
-    """ 
-    Given original input MAF used as an input for GBCMS along with 
-    GBCMS generated output MAF for standard_bam, duplex_bam or simplex bam, 
-    Merge them into a single output MAF format. 
+    """
+    Given original input MAF used as an input for GBCMS along with
+    GBCMS generated output MAF for standard_bam, duplex_bam or simplex bam,
+    Merge them into a single output MAF format.
     If both duplex_bam and simplex_bam based MAF are provided
     the program will generate merged genotypes as well.
     The output file will be based on the give alphanumeric patient identifier as prefix.
@@ -426,16 +426,25 @@ def merge(
             "genotype_variants:small_variants:merge:: STANDARD BAM MAF -> %s",
             input_standard_maf,
         )
+
+        create_empty_maf_if_missing(input_standard_maf)
+
         i_maf = pd.read_csv(
             input_standard_maf, sep="\t", header="infer", index_col=False
         )
     if input_duplex_maf:
+
+        create_empty_maf_if_missing(input_duplex_maf)
+
         d_maf = pd.read_csv(input_duplex_maf, sep="\t", header="infer", index_col=False)
         logger.info(
             "genotype_variants:small_variants:merge:: DUPLEX BAM MAF -> %s",
             input_duplex_maf,
         )
     if input_simplex_maf:
+
+        create_empty_maf_if_missing(input_simplex_maf)
+
         s_maf = pd.read_csv(
             input_simplex_maf, sep="\t", header="infer", index_col=False
         )
@@ -501,6 +510,53 @@ def merge(
     logger.info("CPU process time: %.1f [min]" % ((t2_stop - t2_start) / 60))
     logger.info("--------------------------------------------------")
     return file_name
+
+
+def create_empty_maf_if_missing(filename):
+    header = [
+        'Hugo_Symbol',
+        'Entrez_Gene_Id',
+        'Center',
+        'NCBI_Build',
+        'Chromosome',
+        'Start_Position',
+        'End_Position',
+        'Strand',
+        'Variant_Classification',
+        'Variant_Type',
+        'Reference_Allele',
+        'Tumor_Seq_Allele1',
+        'Tumor_Seq_Allele2',
+        'dbSNP_RS',
+        'dbSNP_Val_Status',
+        'Tumor_Sample_Barcode',
+        'Matched_Norm_Sample_Barcode',
+        'Match_Norm_Seq_Allele1',
+        'Match_Norm_Seq_Allele2',
+        'Tumor_Validation_Allele1',
+        'Tumor_Validation_Allele2',
+        'Match_Norm_Validation_Allele1',
+        'Match_Norm_Validation_Allele2',
+        'Verification_Status',
+        'Validation_Status',
+        'Mutation_Status',
+        'Sequencing_Phase',
+        'Sequence_Source',
+        'Validation_Method',
+        'Score',
+        'BAM_File',
+        'Sequencer',
+        't_ref_count',
+        't_alt_count',
+        'n_ref_count',
+        'n_alt_count',
+        'Caller',
+        't_total_count',
+        't_variant_frequency']
+
+    if not os.path.exists(filename):
+        empty_df = pd.DataFrame(columns=header)
+        empty_df.to_csv(filename, index=False, sep='\t')
 
 
 def write_csv(file_name, data_frame):
@@ -617,9 +673,9 @@ def all(
     threads,
 ):
     """
-    Command that helps to generate genotyped MAF and 
+    Command that helps to generate genotyped MAF and
     merge the genotyped MAF.
-    the output file will be labelled with 
+    the output file will be labelled with
     patient identifier as prefix
     """
     pid = os.getpid()
@@ -734,9 +790,9 @@ def multiple_samples(
     threads,
 ):
     """
-    Command that helps to generate genotyped MAF and 
+    Command that helps to generate genotyped MAF and
     merge the genotyped MAF for multiple samples.
-    the output file will be labelled with 
+    the output file will be labelled with
     patient identifier as prefix
 
     Expected header of metadata_file in any order:
@@ -745,7 +801,7 @@ def multiple_samples(
     standard_bam,
     duplex_bam,
     simplex_bam
-    
+
     For maf, standard_bam, duplex_bam and simplex_bam please include full path to the file.
     """
     pid = os.getpid()

--- a/genotype_variants/create_all_maf_dataframe.py
+++ b/genotype_variants/create_all_maf_dataframe.py
@@ -108,15 +108,15 @@ def create_all_maf_dataframe(
 
         try:
             df_s["t_total_count_reverse_standard"] = (
-                df_s["t_total_count_standard"] - df_s["t_total_count_forward_standard"]
+                df_s["t_total_count_standard"] - df_ds["t_total_count_forward_standard"]
             )
             df_s["t_ref_count_reverse_standard"] = (
                 df_s["t_total_count_reverse_standard"]
-                - df_s["t_ref_count_forward_standard"]
+                - df_ds["t_ref_count_forward_standard"]
             )
             df_s["t_alt_count_reverse_standard"] = (
                 df_s["t_total_count_reverse_standard"]
-                - df_s["t_alt_count_forward_standard"]
+                - df_ds["t_alt_count_forward_standard"]
             )
             logger.debug(
                 "genotype:variants:small_variants::create_all_maf_dataframe:: Successfully generated reverse count columns in standard data frame"
@@ -130,7 +130,7 @@ def create_all_maf_dataframe(
             exit(1)
 
         try:
-            df_s["Tumor_Sample_Barcode"] = df_s["Tumor_Sample_Barcode"].str.replace(
+            df_d["Tumor_Sample_Barcode"] = df_d["Tumor_Sample_Barcode"].str.replace(
                 "-STANDARD", ""
             )
             logger.debug(
@@ -144,7 +144,7 @@ def create_all_maf_dataframe(
             )
 
         try:
-            df_s.set_index(mutation_key, drop=False, inplace=True)
+            df_d.set_index(mutation_key, drop=False, inplace=True)
             logger.debug(
                 "genotype:variants:small_variants:create_all_maf_dataframe:: Successfully reset the index for standard data frame"
             )

--- a/genotype_variants/create_all_maf_dataframe.py
+++ b/genotype_variants/create_all_maf_dataframe.py
@@ -109,17 +109,22 @@ def create_all_maf_dataframe(
             exit(1)
 
         try:
-            df_s["t_alt_count_reverse_standard"] = (
-                df_s["t_alt_count_standard"]
-                - df_s["t_alt_count_forward_standard"]
-            )
-            df_s["t_ref_count_reverse_standard"] = (
-                df_s["t_ref_count_standard"]
-                - df_s["t_ref_count_forward_standard"]
-            )
-            df_s["t_total_count_reverse_standard"] = (
-                df_s["t_total_count_standard"] - df_s["t_total_count_forward_standard"]
-            )
+            if df_s.shape[0] > 0:
+                df_s["t_alt_count_reverse_standard"] = (
+                    df_s["t_alt_count_standard"]
+                    - df_s["t_alt_count_forward_standard"]
+                )
+                df_s["t_ref_count_reverse_standard"] = (
+                    df_s["t_ref_count_standard"]
+                    - df_s["t_ref_count_forward_standard"]
+                )
+                df_s["t_total_count_reverse_standard"] = (
+                    df_s["t_total_count_standard"] - df_s["t_total_count_forward_standard"]
+                )
+            else:
+                df_s["t_alt_count_reverse_standard"] = []
+                df_s["t_ref_count_reverse_standard"] = []
+                df_s["t_total_count_reverse_standard"] = []
             logger.debug(
                 "genotype:variants:small_variants::create_all_maf_dataframe:: Successfully generated reverse count columns in standard data frame"
             )

--- a/genotype_variants/create_all_maf_dataframe.py
+++ b/genotype_variants/create_all_maf_dataframe.py
@@ -108,15 +108,15 @@ def create_all_maf_dataframe(
 
         try:
             df_s["t_total_count_reverse_standard"] = (
-                df_s["t_total_count_standard"] - df_ds["t_total_count_forward_standard"]
+                df_s["t_total_count_standard"] - df_s["t_total_count_forward_standard"]
             )
             df_s["t_ref_count_reverse_standard"] = (
                 df_s["t_total_count_reverse_standard"]
-                - df_ds["t_ref_count_forward_standard"]
+                - df_s["t_ref_count_forward_standard"]
             )
             df_s["t_alt_count_reverse_standard"] = (
                 df_s["t_total_count_reverse_standard"]
-                - df_ds["t_alt_count_forward_standard"]
+                - df_s["t_alt_count_forward_standard"]
             )
             logger.debug(
                 "genotype:variants:small_variants::create_all_maf_dataframe:: Successfully generated reverse count columns in standard data frame"
@@ -130,7 +130,7 @@ def create_all_maf_dataframe(
             exit(1)
 
         try:
-            df_d["Tumor_Sample_Barcode"] = df_d["Tumor_Sample_Barcode"].str.replace(
+            df_s["Tumor_Sample_Barcode"] = df_s["Tumor_Sample_Barcode"].str.replace(
                 "-STANDARD", ""
             )
             logger.debug(
@@ -144,7 +144,7 @@ def create_all_maf_dataframe(
             )
 
         try:
-            df_d.set_index(mutation_key, drop=False, inplace=True)
+            df_s.set_index(mutation_key, drop=False, inplace=True)
             logger.debug(
                 "genotype:variants:small_variants:create_all_maf_dataframe:: Successfully reset the index for standard data frame"
             )

--- a/genotype_variants/create_all_maf_dataframe.py
+++ b/genotype_variants/create_all_maf_dataframe.py
@@ -108,8 +108,8 @@ def create_all_maf_dataframe(
             )
             exit(1)
 
-        try:
-            if df_s.shape[0] > 0:
+        if df_s.shape[0] > 0:
+            try:
                 df_s["t_alt_count_reverse_standard"] = (
                     df_s["t_alt_count_standard"]
                     - df_s["t_alt_count_forward_standard"]
@@ -121,20 +121,20 @@ def create_all_maf_dataframe(
                 df_s["t_total_count_reverse_standard"] = (
                     df_s["t_total_count_standard"] - df_s["t_total_count_forward_standard"]
                 )
-            else:
-                df_s["t_alt_count_reverse_standard"] = []
-                df_s["t_ref_count_reverse_standard"] = []
-                df_s["t_total_count_reverse_standard"] = []
-            logger.debug(
-                "genotype:variants:small_variants::create_all_maf_dataframe:: Successfully generated reverse count columns in standard data frame"
-            )
-        except:
-            e = sys.exc_info()[0]
-            logger.error(
-                "genotype:variants:small_variants::create_all_maf_dataframe:: Could not generate reverse count columns in standard data frame due to error, %s",
-                e,
-            )
-            exit(1)
+                logger.debug(
+                    "genotype:variants:small_variants::create_all_maf_dataframe:: Successfully generated reverse count columns in standard data frame"
+                )
+            except:
+                e = sys.exc_info()[0]
+                logger.error(
+                    "genotype:variants:small_variants::create_all_maf_dataframe:: Could not generate reverse count columns in standard data frame due to error, %s",
+                    e
+                )
+                exit(1)
+        else:
+            df_s["t_alt_count_reverse_standard"] = []
+            df_s["t_ref_count_reverse_standard"] = []
+            df_s["t_total_count_reverse_standard"] = []
 
         try:
             df_s["Tumor_Sample_Barcode"] = df_s["Tumor_Sample_Barcode"].str.replace(

--- a/genotype_variants/create_duplex_simplex_dataframe.py
+++ b/genotype_variants/create_duplex_simplex_dataframe.py
@@ -67,9 +67,12 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         exit(1)
 
     try:
-        df_s["t_total_count_fragment_simplex"] = (
-            df_s["t_ref_count_fragment_simplex"] + df_s["t_alt_count_fragment_simplex"]
-        )
+        if df_s.shape[0] > 0:
+            df_s["t_total_count_fragment_simplex"] = (
+                df_s["t_ref_count_fragment_simplex"] + df_s["t_alt_count_fragment_simplex"]
+            )
+        else:
+            df_s["t_total_count_fragment_simplex"] = []
         logger.debug(
             "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Successfully generated t_total_count_fragment_simplex column"
         )
@@ -82,13 +85,16 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         exit(1)
 
     try:
-        df_s["t_vaf_fragment_simplex"] = (
-            df_s["t_alt_count_fragment_simplex"]
-            / (
-                df_s["t_alt_count_fragment_simplex"].astype(int)
-                + df_s["t_ref_count_fragment_simplex"].astype(int)
-            )
-        ).round(4)
+        if df_s.shape[0] > 0:
+            df_s["t_vaf_fragment_simplex"] = (
+                df_s["t_alt_count_fragment_simplex"]
+                / (
+                    df_s["t_alt_count_fragment_simplex"].astype(int)
+                    + df_s["t_ref_count_fragment_simplex"].astype(int)
+                )
+            ).round(4)
+        else:
+            df_s["t_vaf_fragment_simplex"] = []
         df_s["t_vaf_fragment_simplex"].fillna(0, inplace=True)
         logger.debug(
             "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated t_vaf_fragment_simplex column"
@@ -162,9 +168,12 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         exit(1)
 
     try:
-        df_d["t_total_count_fragment_duplex"] = (
-            df_d["t_ref_count_fragment_duplex"] + df_d["t_alt_count_fragment_duplex"]
-        )
+        if df_d.shape[0] > 0:
+            df_d["t_total_count_fragment_duplex"] = (
+                df_d["t_ref_count_fragment_duplex"] + df_d["t_alt_count_fragment_duplex"]
+            )
+        else:
+            df_d["t_total_count_fragment_duplex"] = []
         logger.debug(
             "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Successfully generated t_total_count_fragment_duplex column"
         )
@@ -177,13 +186,16 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         exit(1)
 
     try:
-        df_d["t_vaf_fragment_duplex"] = (
-            df_d["t_alt_count_fragment_duplex"]
-            / (
-                df_d["t_alt_count_fragment_duplex"].astype(int)
-                + df_d["t_ref_count_fragment_duplex"].astype(int)
-            )
-        ).round(4)
+        if df_d.shape[0] > 0:
+            df_d["t_vaf_fragment_duplex"] = (
+                df_d["t_alt_count_fragment_duplex"]
+                / (
+                    df_d["t_alt_count_fragment_duplex"].astype(int)
+                    + df_d["t_ref_count_fragment_duplex"].astype(int)
+                )
+            ).round(4)
+        else:
+            df_d["t_vaf_fragment_duplex"] = []
         df_d["t_vaf_fragment_duplex"].fillna(0, inplace=True)
         logger.debug(
             "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated t_vaf_fragment_duplex column"
@@ -250,23 +262,29 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         exit(1)
     ##Add
     try:
-        df_ds["t_ref_count_fragment_simplex_duplex"] = (
-            df_ds["t_ref_count_fragment_simplex"] + df_ds["t_ref_count_fragment_duplex"]
-        )
-        df_ds["t_alt_count_fragment_simplex_duplex"] = (
-            df_ds["t_alt_count_fragment_simplex"] + df_ds["t_alt_count_fragment_duplex"]
-        )
-        df_ds["t_total_count_fragment_simplex_duplex"] = (
-            df_ds["t_alt_count_fragment_simplex_duplex"]
-            + df_ds["t_ref_count_fragment_simplex_duplex"]
-        )
-        df_ds["t_vaf_fragment_simplex_duplex"] = (
-            df_ds["t_alt_count_fragment_simplex_duplex"]
-            / (
-                df_ds["t_alt_count_fragment_simplex_duplex"].astype(int)
-                + df_ds["t_ref_count_fragment_simplex_duplex"].astype(int)
+        if df_ds.shape[0] > 0:
+            df_ds["t_ref_count_fragment_simplex_duplex"] = (
+                df_ds["t_ref_count_fragment_simplex"] + df_ds["t_ref_count_fragment_duplex"]
             )
-        ).round(4)
+            df_ds["t_alt_count_fragment_simplex_duplex"] = (
+                df_ds["t_alt_count_fragment_simplex"] + df_ds["t_alt_count_fragment_duplex"]
+            )
+            df_ds["t_total_count_fragment_simplex_duplex"] = (
+                df_ds["t_alt_count_fragment_simplex_duplex"]
+                + df_ds["t_ref_count_fragment_simplex_duplex"]
+            )
+            df_ds["t_vaf_fragment_simplex_duplex"] = (
+                df_ds["t_alt_count_fragment_simplex_duplex"]
+                / (
+                    df_ds["t_alt_count_fragment_simplex_duplex"].astype(int)
+                    + df_ds["t_ref_count_fragment_simplex_duplex"].astype(int)
+                )
+            ).round(4)
+        else:
+            df_ds["t_ref_count_fragment_simplex_duplex"] = []
+            df_ds["t_alt_count_fragment_simplex_duplex"] = []
+            df_ds["t_total_count_fragment_simplex_duplex"] = []
+            df_ds["t_vaf_fragment_simplex_duplex"] = []
         df_ds["t_vaf_fragment_simplex_duplex"].fillna(0, inplace=True)
         logger.debug(
             "genotype_variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated column for merged counts"

--- a/genotype_variants/create_duplex_simplex_dataframe.py
+++ b/genotype_variants/create_duplex_simplex_dataframe.py
@@ -66,26 +66,26 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         )
         exit(1)
 
-    try:
-        if df_s.shape[0] > 0:
+    if df_s.shape[0] > 0:
+        try:
             df_s["t_total_count_fragment_simplex"] = (
                 df_s["t_ref_count_fragment_simplex"] + df_s["t_alt_count_fragment_simplex"]
             )
-        else:
-            df_s["t_total_count_fragment_simplex"] = []
-        logger.debug(
-            "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Successfully generated t_total_count_fragment_simplex column"
-        )
-    except:
-        e = sys.exc_info()[0]
-        logger.error(
-            "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_total_count_fragment_simplex column due to error, %s",
-            e,
-        )
-        exit(1)
+            logger.debug(
+                "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Successfully generated t_total_count_fragment_simplex column"
+            )
+        except:
+            e = sys.exc_info()[0]
+            logger.error(
+                "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_total_count_fragment_simplex column due to error, %s",
+                e
+            )
+            exit(1)
+    else:
+        df_s["t_total_count_fragment_simplex"] = []
 
-    try:
-        if df_s.shape[0] > 0:
+    if df_s.shape[0] > 0:
+        try:
             df_s["t_vaf_fragment_simplex"] = (
                 df_s["t_alt_count_fragment_simplex"]
                 / (
@@ -93,19 +93,19 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
                     + df_s["t_ref_count_fragment_simplex"].astype(int)
                 )
             ).round(4)
-        else:
-            df_s["t_vaf_fragment_simplex"] = []
-        df_s["t_vaf_fragment_simplex"].fillna(0, inplace=True)
-        logger.debug(
-            "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated t_vaf_fragment_simplex column"
-        )
-    except:
-        e = sys.exc_info()[0]
-        logger.error(
-            "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_vaf_fragment_simplex column due to error, %s",
-            e,
-        )
-        exit(1)
+            df_s["t_vaf_fragment_simplex"].fillna(0, inplace=True)
+            logger.debug(
+                "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated t_vaf_fragment_simplex column"
+            )
+        except:
+            e = sys.exc_info()[0]
+            logger.error(
+                "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_vaf_fragment_simplex column due to error, %s",
+                e
+            )
+            exit(1)
+    else:
+        df_s["t_vaf_fragment_simplex"] = []
 
     try:
         df_s["Tumor_Sample_Barcode"] = df_s["Tumor_Sample_Barcode"].str.replace(
@@ -167,26 +167,26 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
         )
         exit(1)
 
-    try:
-        if df_d.shape[0] > 0:
+    if df_d.shape[0] > 0:
+        try:
             df_d["t_total_count_fragment_duplex"] = (
                 df_d["t_ref_count_fragment_duplex"] + df_d["t_alt_count_fragment_duplex"]
             )
-        else:
-            df_d["t_total_count_fragment_duplex"] = []
-        logger.debug(
-            "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Successfully generated t_total_count_fragment_duplex column"
-        )
-    except:
-        e = sys.exc_info()[0]
-        logger.error(
-            "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_total_count_fragment_duplex column due to error, %s",
-            e,
-        )
-        exit(1)
+            logger.debug(
+                "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Successfully generated t_total_count_fragment_duplex column"
+            )
+        except:
+            e = sys.exc_info()[0]
+            logger.error(
+                "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_total_count_fragment_duplex column due to error, %s",
+                e
+            )
+            exit(1)
+    else:
+        df_d["t_total_count_fragment_duplex"] = []
 
-    try:
-        if df_d.shape[0] > 0:
+    if df_d.shape[0] > 0:
+        try:
             df_d["t_vaf_fragment_duplex"] = (
                 df_d["t_alt_count_fragment_duplex"]
                 / (
@@ -194,19 +194,19 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
                     + df_d["t_ref_count_fragment_duplex"].astype(int)
                 )
             ).round(4)
-        else:
-            df_d["t_vaf_fragment_duplex"] = []
-        df_d["t_vaf_fragment_duplex"].fillna(0, inplace=True)
-        logger.debug(
-            "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated t_vaf_fragment_duplex column"
-        )
-    except:
-        e = sys.exc_info()[0]
-        logger.error(
-            "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_vaf_fragment_duplex column due to error, %s",
-            e,
-        )
-        exit(1)
+            df_d["t_vaf_fragment_duplex"].fillna(0, inplace=True)
+            logger.debug(
+                "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated t_vaf_fragment_duplex column"
+            )
+        except:
+            e = sys.exc_info()[0]
+            logger.error(
+                "genotype:variants:small_variants::create_duplex_simplex_dataframe:: Could not generate t_vaf_fragment_duplex column due to error, %s",
+                e
+            )
+            exit(1)
+    else:
+        df_d["t_vaf_fragment_duplex"] = []
 
     try:
         df_d["Tumor_Sample_Barcode"] = df_d["Tumor_Sample_Barcode"].str.replace(
@@ -260,9 +260,10 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
             e,
         )
         exit(1)
+
     ##Add
-    try:
-        if df_ds.shape[0] > 0:
+    if df_ds.shape[0] > 0:
+        try:
             df_ds["t_ref_count_fragment_simplex_duplex"] = (
                 df_ds["t_ref_count_fragment_simplex"] + df_ds["t_ref_count_fragment_duplex"]
             )
@@ -280,22 +281,22 @@ def create_duplex_simplex_dataframe(simplex_dataframe, duplex_dataframe):
                     + df_ds["t_ref_count_fragment_simplex_duplex"].astype(int)
                 )
             ).round(4)
-        else:
-            df_ds["t_ref_count_fragment_simplex_duplex"] = []
-            df_ds["t_alt_count_fragment_simplex_duplex"] = []
-            df_ds["t_total_count_fragment_simplex_duplex"] = []
-            df_ds["t_vaf_fragment_simplex_duplex"] = []
-        df_ds["t_vaf_fragment_simplex_duplex"].fillna(0, inplace=True)
-        logger.debug(
-            "genotype_variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated column for merged counts"
-        )
-    except:
-        e = sys.exc_info()[0]
-        logger.error(
-            "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Could not generate merged count column in the merged data frame due to error, %s",
-            e,
-        )
-        exit(1)
+            df_ds["t_vaf_fragment_simplex_duplex"].fillna(0, inplace=True)
+            logger.debug(
+                "genotype_variants:small_variants:create_duplex_simplex_dataframe:: Successfully generated column for merged counts"
+            )
+        except:
+            e = sys.exc_info()[0]
+            logger.error(
+                "genotype:variants:small_variants:create_duplex_simplex_dataframe:: Could not generate merged count column in the merged data frame due to error, %s",
+                e
+            )
+            exit(1)
+    else:
+        df_ds["t_ref_count_fragment_simplex_duplex"] = []
+        df_ds["t_alt_count_fragment_simplex_duplex"] = []
+        df_ds["t_total_count_fragment_simplex_duplex"] = []
+        df_ds["t_vaf_fragment_simplex_duplex"] = []
 
     ##clean up
     try:


### PR DESCRIPTION
I made these changes to handle the case for when I have ACCESS tumor samples that don't have any mutations AND also meets one of the following conditions:

- It has no DMP sample
- It has a DMP sample, but it has no mutations.

I successfully tested these changes on a project that had samples in both of the above categories.

Specifically, these changes allow me to run the compile_reads.R script successfully.